### PR TITLE
+ new supported menus, changed the keytips generation logic to support all these menus

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -26,7 +26,6 @@ local LETTER_MAPS = {
   FREEZE  = { F = {"Freeze Panes"}, R = {"Freeze Top Row"}, C = {"Freeze First Column"} },
   INSERT  = { I = {"Insert Cells"}, R = {"Insert Sheet Rows"}, C = {"Insert Sheet Columns"}, S = {"Insert Sheet"} },
   DELETE  = { D = {"Delete Cells"}, R = {"Delete Sheet Rows"}, C = {"Delete Sheet Columns"}, T = {"Delete Table Rows"}, L = {"Delete Table Columns"}, S = {"Delete Sheet"} },
-  DELETE  = { D = {"Delete Cells"}, R = {"Delete Sheet Rows"}, C = {"Delete Sheet Columns"}, T = {"Delete Table Rows"}, L = {"Delete Table Columns"}, S = {"Delete Sheet"} },
   PASTE = { A = {"Paste"}, F = {"Formulas"}, N = {"Formulas & Number Formatting"}, S = {"Keep Source Formatting"}, B = {"No Borders"}, W = {"Keep Source Column Widths"}, T = {"Transpose"}, V = {"Paste Values"}, U = {"Values & Number Formatting"}, O = {"Values & Source Formatting"}, R = {"Formatting"}, L = {"Paste Link"}, P = {"Paste as Picture"}, I = {"Linked Picture"}, M = {"Match Destination Formatting"}, E = {"Paste Special"}},
   COPY  = { C = {"Copy"}, P = {"Copy as Picture"}},
   GROUP  = { G = {"Group"}},

--- a/init.lua
+++ b/init.lua
@@ -46,14 +46,14 @@ local CONTEXTS = {
   { name = "delete", map = LETTER_MAPS.DELETE, minButtons = 5, trigger = "d", parent_menu_trigger = "h" },
   { name = "paste", map = LETTER_MAPS.PASTE, minButtons = 1, trigger = "v", parent_menu_trigger = "h" },
   { name = "copy", map = LETTER_MAPS.COPY, minButtons = 1, trigger = "c", parent_menu_trigger = "h" },
-  { name = "rotate", map = LETTER_MAPS.ROTATE, minButtons = 4, trigger = "q", parent_menu_trigger = "h" },
+  { name = "rotate", map = LETTER_MAPS.ROTATE, minButtons = 4, trigger = "fq", parent_menu_trigger = "h" },
   { name = "group", map = LETTER_MAPS.GROUP, minButtons = 1, trigger = "g", parent_menu_trigger = "a" },
   { name = "ungroup", map = LETTER_MAPS.UNGROUP, minButtons = 1, trigger = "u", parent_menu_trigger = "a" },
   { name = "autosum", map = LETTER_MAPS.AUTOSUM, minButtons = 5, trigger = "u", parent_menu_trigger = "h" },
-  { name = "fill", map = LETTER_MAPS.FILL, minButtons = 6, trigger = "i", parent_menu_trigger = "h" },
+  { name = "fill", map = LETTER_MAPS.FILL, minButtons = 6, trigger = "fi", parent_menu_trigger = "h" },
   { name = "clear", map = LETTER_MAPS.CLEAR, minButtons = 5, trigger = "e", parent_menu_trigger = "h" },
   { name = "sort", map = LETTER_MAPS.SORT, minButtons = 5, trigger = "s", parent_menu_trigger = "h" },
-  { name = "find", map = LETTER_MAPS.FIND, minButtons = 6, trigger = "d", parent_menu_trigger = "h" },
+  { name = "find", map = LETTER_MAPS.FIND, minButtons = 6, trigger = "fd", parent_menu_trigger = "h" },
 }
 
 -- Build trigger sequence to context mapping (1–2 letter triggers)


### PR DESCRIPTION
With this pull request the following additional menus are supported:

- MERGE 
- PASTE 
- COPY  
- GROUP
- UNGROUP 
- AUTOSUM
- FILL
- CLEAR 
- SORT
- FIND 

I had to change the keytips generation logic to handle multiple CONTEXTS with the same key assigned. Now instead of having a global event handler that checks what keys are pressed, there is a local event handler and a local key assigned for each context menu. 
The keytips will now activate when two conditions are met: the key for the corresponding context menu has been pressed and the expected elements of the context menu are visible.

Currently the code handles context menus that have multiple keys by checking for the last key that has to be pressed in order to open the context menu. 
E.g.: to open the "Find & Select" context menu, one need to press FD. The code will populate the Find & Select context menu with the keytips when D is clicked.



